### PR TITLE
feat: fix to use `autoware_internal_planning_msgs`

### DIFF
--- a/config/trajectory_optimizer.param.yaml
+++ b/config/trajectory_optimizer.param.yaml
@@ -5,7 +5,7 @@
     nearest_yaw_threshold_rad: 1.0 # [rad]
     target_pull_out_speed_mps: 1.0 # [mps]
     target_pull_out_acc_mps2: 1.0 # [mps2]
-    max_speed_mps: 8.32 #[5 kmph], 2.77[10 kmph], 4.16[15 kmph] [mps]
+    max_speed_mps: 5.0 #[5 kmph], 2.77[10 kmph], 4.16[15 kmph] [mps]
     max_lateral_accel_mps2: 1.5 #[mps2]
     spline_interpolation_resolution_m: 0.5 # [m]
     backward_trajectory_extension_m: 5.0 # [m]
@@ -15,7 +15,7 @@
     limit_lateral_acceleration: true
     set_engage_speed: false
     fix_invalid_points: true
-    smooth_velocities: true
+    smooth_velocities: false
     publish_last_trajectory: false
     keep_last_trajectory: false
     extend_trajectory_backward: true

--- a/config/trajectory_optimizer.param.yaml
+++ b/config/trajectory_optimizer.param.yaml
@@ -5,7 +5,7 @@
     nearest_yaw_threshold_rad: 1.0 # [rad]
     target_pull_out_speed_mps: 1.0 # [mps]
     target_pull_out_acc_mps2: 1.0 # [mps2]
-    max_speed_mps: 5.0 #[5 kmph], 2.77[10 kmph], 4.16[15 kmph] [mps]
+    max_speed_mps: 8.32 #[5 kmph], 2.77[10 kmph], 4.16[15 kmph] [mps]
     max_lateral_accel_mps2: 1.5 #[mps2]
     spline_interpolation_resolution_m: 0.5 # [m]
     backward_trajectory_extension_m: 5.0 # [m]
@@ -15,7 +15,7 @@
     limit_lateral_acceleration: true
     set_engage_speed: false
     fix_invalid_points: true
-    smooth_velocities: false
+    smooth_velocities: true
     publish_last_trajectory: false
     keep_last_trajectory: false
     extend_trajectory_backward: true

--- a/config/velocity_smoothing/default_velocity_smoother.param.yaml
+++ b/config/velocity_smoothing/default_velocity_smoother.param.yaml
@@ -12,14 +12,15 @@
     curvature_calculation_distance: 5.0 # distance of points while curvature is calculating for the steer rate and lateral acceleration limit [m]
     # - lateral acceleration limit parameters -
     enable_lateral_acc_limit: true # To toggle the lateral acc filter on and off. You can switch it dynamically at runtime.
-    max_lateral_accel: 0.8 # max lateral acceleration limit [m/ss]
+    lateral_acceleration_limits: [0.8, 0.8, 0.8, 0.8] # max lateral acceleration limit [m/ss]
     min_curve_velocity: 2.74 # min velocity at lateral acceleration limit and steering angle rate limit [m/s]
     decel_distance_before_curve: 3.5 # slow speed distance before a curve for lateral acceleration limit
     decel_distance_after_curve: 2.0 # slow speed distance after a curve for lateral acceleration limit
     min_decel_for_lateral_acc_lim_filter: -2.5 # deceleration limit applied in the lateral acceleration filter to avoid sudden braking [m/ss]
     # - steering angle rate limit parameters -
     enable_steering_rate_limit: true # To toggle the steer rate filter on and off. You can switch it dynamically at runtime.
-    max_steering_angle_rate: 40.0 # maximum steering angle rate [degree/s]
+    velocity_thresholds: [0.1, 0.3, 20.0, 30.0]           # velocity thresholds in mps for steering angle rate limits [m/s]
+    steering_angle_rate_limits: [11.5, 11.5, 10.5, 3.5]  # steering angle rates in degree for each velocity range [deg/s]
     resample_ds: 0.1 # distance between trajectory points [m]
     curvature_threshold: 0.02 # if curvature > curvature_threshold, steeringRateLimit is triggered [1/m]
 

--- a/include/autoware/trajectory_optimizer/trajectory_optimizer.hpp
+++ b/include/autoware/trajectory_optimizer/trajectory_optimizer.hpp
@@ -31,7 +31,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/subscription.hpp>
 
-#include <autoware_new_planning_msgs/msg/trajectories.hpp>
+#include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
 #include <autoware_perception_msgs/msg/detail/predicted_objects__struct.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/detail/trajectory__struct.hpp>
@@ -55,14 +55,14 @@ using autoware::path_smoother::ReplanChecker;
 using SmootherTimekeeper = autoware::path_smoother::TimeKeeper;
 
 using autoware::velocity_smoother::JerkFilteredSmoother;
-using autoware_new_planning_msgs::msg::Trajectories;
+using autoware_internal_planning_msgs::msg::CandidateTrajectories;
+using autoware_internal_planning_msgs::msg::CandidateTrajectory;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
-using NewTrajectory = autoware_new_planning_msgs::msg::Trajectory;
 
 class TrajectoryOptimizer : public rclcpp::Node
 {
@@ -70,7 +70,7 @@ public:
   explicit TrajectoryOptimizer(const rclcpp::NodeOptions & options);
 
 private:
-  void on_traj(const Trajectories::ConstSharedPtr msg);
+  void on_traj(const CandidateTrajectories::ConstSharedPtr msg);
   void set_up_params();
   void initialize_planners();
   void reset_previous_data();
@@ -93,9 +93,10 @@ private:
   std::shared_ptr<plugin::TrajectoryVelocityOptimizer> trajectory_velocity_optimizer_ptr_;
 
   // interface subscriber
-  rclcpp::Subscription<Trajectories>::SharedPtr trajectories_sub_;
+  rclcpp::Subscription<CandidateTrajectories>::SharedPtr trajectories_sub_;
   // interface publisher
-  rclcpp::Publisher<Trajectories>::SharedPtr trajectories_pub_;
+  rclcpp::Publisher<Trajectory>::SharedPtr trajectory_pub_;
+  rclcpp::Publisher<CandidateTrajectories>::SharedPtr trajectories_pub_;
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr debug_processing_time_detail_;
 
   autoware_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{

--- a/include/autoware/trajectory_optimizer/trajectory_optimizer.hpp
+++ b/include/autoware/trajectory_optimizer/trajectory_optimizer.hpp
@@ -32,10 +32,7 @@
 #include <rclcpp/subscription.hpp>
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
-#include <autoware_perception_msgs/msg/detail/predicted_objects__struct.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
-#include <autoware_planning_msgs/msg/detail/trajectory__struct.hpp>
-#include <autoware_planning_msgs/msg/detail/trajectory_point__struct.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>

--- a/include/autoware/trajectory_optimizer/utils.hpp
+++ b/include/autoware/trajectory_optimizer/utils.hpp
@@ -24,6 +24,7 @@
 
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
 #include <autoware_new_planning_msgs/msg/trajectories.hpp>
 #include <autoware_perception_msgs/msg/detail/predicted_objects__struct.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
@@ -44,13 +45,13 @@ using autoware::path_smoother::PlannerData;
 using autoware::path_smoother::ReplanChecker;
 
 using autoware::velocity_smoother::JerkFilteredSmoother;
+using autoware_internal_planning_msgs::msg::CandidateTrajectory;
 using autoware_new_planning_msgs::msg::Trajectories;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
-using NewTrajectory = autoware_new_planning_msgs::msg::Trajectory;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 
 void smooth_trajectory_with_elastic_band(

--- a/include/autoware/trajectory_optimizer/utils.hpp
+++ b/include/autoware/trajectory_optimizer/utils.hpp
@@ -25,7 +25,6 @@
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
-#include <autoware_new_planning_msgs/msg/trajectories.hpp>
 #include <autoware_perception_msgs/msg/detail/predicted_objects__struct.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/detail/trajectory__struct.hpp>
@@ -46,7 +45,6 @@ using autoware::path_smoother::ReplanChecker;
 
 using autoware::velocity_smoother::JerkFilteredSmoother;
 using autoware_internal_planning_msgs::msg::CandidateTrajectory;
-using autoware_new_planning_msgs::msg::Trajectories;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <depend>autoware_motion_utils</depend>
   <depend>autoware_new_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_path_smoother</depend>

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>autoware_motion_utils</depend>
-  <depend>autoware_new_planning_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_trajectory</depend>

--- a/src/trajectory_optimizer.cpp
+++ b/src/trajectory_optimizer.cpp
@@ -24,8 +24,8 @@
 #include <autoware_utils/ros/update_param.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
-#include <autoware_internal_planning_msgs/msg/detail/candidate_trajectories__struct.hpp>
-#include <autoware_planning_msgs/msg/detail/trajectory_point__struct.hpp>
+#include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
 
 #include <algorithm>
 #include <cstddef>


### PR DESCRIPTION
This PR migrates the optimizer to use `autoware_internal_planning_msgs` instead of the old planning messages, adds a dedicated single‐trajectory publisher, and tweaks default parameters in the smoother and optimizer configs.

- Replace all `Trajectories` usages with `CandidateTrajectories` and adjust includes/subscribers/publishers accordingly
- Introduce `trajectory_pub_` for publishing the top candidate separately
- Update package dependency and default YAML parameters for velocity smoothing and max speed